### PR TITLE
Update zillow_runfile.py because of Module Error

### DIFF
--- a/zillow_runfile.py
+++ b/zillow_runfile.py
@@ -20,7 +20,7 @@ Software requirements/info:
 import time
 import pandas as pd
 from bs4 import BeautifulSoup
-import Zillow.zillow_functions as zl
+import zillow_functions as zl
 
 # Create list of search terms.
 # Function zipcodes_list() creates a list of US zip codes that will be 


### PR DESCRIPTION
'Zillow' Module doesn't exist, so I fixed it by changing 
`import Zillow.zillow_functions as zl`
to
`import zillow_functions as zl`
As it was before.